### PR TITLE
fix: correct grammatical errors in documentation comments

### DIFF
--- a/crates/evm/src/block/system_calls/eip4788.rs
+++ b/crates/evm/src/block/system_calls/eip4788.rs
@@ -13,7 +13,7 @@ use revm::context_interface::result::ResultAndState;
 /// Applies the pre-block call to the [EIP-4788] beacon block root contract, using the given block,
 /// chain spec, EVM.
 ///
-/// Note: this does not commit the state changes to the database, it only transact the call.
+/// Note: this does not commit the state changes to the database, it only transacts the call.
 ///
 /// Returns `None` if Cancun is not active or the block is the genesis block, otherwise returns the
 /// result of the call.

--- a/crates/evm/src/block/system_calls/eip7002.rs
+++ b/crates/evm/src/block/system_calls/eip7002.rs
@@ -14,7 +14,7 @@ use revm::context_interface::result::{ExecutionResult, ResultAndState};
 ///
 /// If Prague is not active at the given timestamp, then this is a no-op.
 ///
-/// Note: this does not commit the state changes to the database, it only transact the call.
+/// Note: this does not commit the state changes to the database, it only transacts the call.
 #[inline]
 pub(crate) fn transact_withdrawal_requests_contract_call<Halt>(
     evm: &mut impl Evm<HaltReason = Halt>,

--- a/crates/evm/src/block/system_calls/eip7251.rs
+++ b/crates/evm/src/block/system_calls/eip7251.rs
@@ -15,7 +15,7 @@ use revm::context_interface::result::{ExecutionResult, ResultAndState};
 /// If Prague is not active at the given timestamp, then this is a no-op, and an empty vector is
 /// returned. Otherwise, the consolidation requests are returned.
 ///
-/// Note: this does not commit the state changes to the database, it only transact the call.
+/// Note: this does not commit the state changes to the database, it only transacts the call.
 #[inline]
 pub(crate) fn transact_consolidation_requests_contract_call<Halt>(
     evm: &mut impl Evm<HaltReason = Halt>,

--- a/crates/evm/src/traits.rs
+++ b/crates/evm/src/traits.rs
@@ -169,7 +169,7 @@ impl<'a> EvmInternals<'a> {
         Self { internals: Box::new(EvmInternalsImpl(journal)), block_env }
     }
 
-    /// Returns the  evm's block information.
+    /// Returns the evm's block information.
     pub const fn block_env(&self) -> impl Block + 'a {
         self.block_env
     }


### PR DESCRIPTION
- Fix double space in 'Returns the evm's block information' comment
- Fix 'transact' to 'transacts' in system call documentation comments

These changes improve the clarity and correctness of the documentation.


- [ ] Added Documentation

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/alloy-evm/1)
<!-- Reviewable:end -->
