### PR TITLE
Cross-chain bridge — execution-layer hook (alloy-evm)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ auto_impl = "1"
 derive_more = { version = "2", default-features = false, features = ["full"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 thiserror = { version = "2.0.0", default-features = false }
+tracing = { version = "0.1", default-features = false }
 serde_json = "1"
 test-case = "3"
 

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -28,6 +28,7 @@ op-alloy-consensus = { workspace = true, optional = true }
 auto_impl.workspace = true
 derive_more.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["serde"] }

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -51,7 +51,8 @@ std = [
     "op-revm?/std",
     "thiserror/std",
     "op-alloy-consensus?/std",
-    "alloy-rpc-types-eth?/std"
+    "alloy-rpc-types-eth?/std",
+    "tracing/std"
 ]
 op = ["op-revm", "op-alloy-consensus"]
 overrides = ["dep:alloy-rpc-types-eth"]

--- a/crates/evm/src/block/state_hook.rs
+++ b/crates/evm/src/block/state_hook.rs
@@ -39,6 +39,8 @@ pub enum StateChangePostBlockSource {
     ConsolidationRequestsContract,
     /// Staking distribution from block rewards and withdrawals
     StakingDistribution,
+    /// 0G Bridge inbound message execution (EIP-7685 type byte `0xf0`, private 0G namespace).
+    BridgeExecution,
 }
 
 impl<F> OnStateHook for F

--- a/crates/evm/src/block/system_calls/bridge.rs
+++ b/crates/evm/src/block/system_calls/bridge.rs
@@ -1,0 +1,184 @@
+//! 0G Bridge inbound message system call.
+//!
+//! This is the EL-side counterpart to the EIP-7685 request type `0xf0` carried on the engine
+//! API in 0G's private namespace. The CL beacon block emits a list of `BridgeMessage` items
+//! as SSZ bytes; the EL decodes them into ABI calldata for
+//! `Bridge.executeRemoteMessages(InboundMessage[])` and invokes the Bridge proxy contract
+//! from the canonical [`SYSTEM_ADDRESS`] just like EIP-4788/7002.
+//!
+//! Activation is gated by [`EthExecutorSpec::is_bridge_active_at_timestamp`] and a configured
+//! [`EthExecutorSpec::bridge_contract_address`]. The hook is a no-op (returns `Ok(None)`) when
+//! either gate is closed, when no calldata was attached to the block context, or when the
+//! attached calldata is empty.
+
+use crate::{block::BlockExecutionError, eth::spec::EthExecutorSpec, Evm};
+use alloc::format;
+use alloy_eips::eip7002::SYSTEM_ADDRESS;
+use alloy_primitives::Bytes;
+use revm::context_interface::result::ResultAndState;
+
+/// EIP-7685 request type byte for 0G's cross-chain Bridge messages (private namespace).
+///
+/// Emitted as the **last** entry of `executionRequests` post-Bridge fork — strictly after the
+/// standard 0x00/0x01/0x02 (deposit/withdrawal/consolidation) entries to satisfy EIP-7685's
+/// monotonic type-byte ordering required by the bridge schema.
+pub const BRIDGE_REQUEST_TYPE: u8 = 0xf0;
+
+/// Invokes `Bridge.executeRemoteMessages(InboundMessage[])` from [`SYSTEM_ADDRESS`].
+///
+/// Returns `Ok(None)` (no-op) if any of the following gates is closed:
+///   * Bridge fork not active at `timestamp` (`spec.is_bridge_active_at_timestamp`)
+///   * Chain spec has no configured bridge contract address
+///   * No calldata was attached to the block execution context
+///   * Attached calldata is empty
+///
+/// On the active path the call uses the standard `transact_system_call` semantics: 30M gas,
+/// no fee charged, no coinbase reward, executed against the same EVM state as block transactions.
+/// The state delta is **not** committed by this function — the caller is responsible for
+/// wiring the result into [`SystemCaller::on_state`] and calling `db.commit(...)`.
+#[inline]
+pub(crate) fn transact_bridge_contract_call<Halt>(
+    spec: &impl EthExecutorSpec,
+    timestamp: u64,
+    calldata: Option<&Bytes>,
+    evm: &mut impl Evm<HaltReason = Halt>,
+) -> Result<Option<ResultAndState<Halt>>, BlockExecutionError> {
+    // Gate 1: fork-version timestamp
+    if !spec.is_bridge_active_at_timestamp(timestamp) {
+        return Ok(None);
+    }
+
+    // Gate 2: configured contract address
+    let target = match spec.bridge_contract_address() {
+        Some(addr) => addr,
+        None => return Ok(None),
+    };
+
+    // Gate 3 + 4: non-empty calldata supplied by the engine API
+    let cd = match calldata {
+        Some(b) if !b.is_empty() => b.clone(),
+        _ => return Ok(None),
+    };
+
+    let res = match evm.transact_system_call(SYSTEM_ADDRESS, target, cd) {
+        Ok(res) => res,
+        Err(e) => {
+            return Err(BlockExecutionError::msg(format!(
+                "0G bridge system call execution failed: {e}"
+            )));
+        }
+    };
+    Ok(Some(res))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_eips::eip7002::SYSTEM_ADDRESS as EIP7002_SYSTEM_ADDRESS;
+    use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
+    use alloy_primitives::{address, Address};
+
+    /// Lightweight spec used to drive the gate logic. The wider `Evm` integration is exercised
+    /// by an integration test in the consuming reth crate against a real revm instance.
+    #[derive(Debug, Clone, Default)]
+    struct MockSpec {
+        bridge_address: Option<Address>,
+        bridge_active: bool,
+    }
+
+    impl EthereumHardforks for MockSpec {
+        fn ethereum_fork_activation(&self, _fork: EthereumHardfork) -> ForkCondition {
+            ForkCondition::Never
+        }
+    }
+
+    impl EthExecutorSpec for MockSpec {
+        fn deposit_contract_address(&self) -> Option<Address> {
+            None
+        }
+        fn staking_contract_address(&self) -> Option<Address> {
+            None
+        }
+        fn is_staking_activate_at_timestamp(&self, _t: u64) -> bool {
+            false
+        }
+        fn bridge_contract_address(&self) -> Option<Address> {
+            self.bridge_address
+        }
+        fn is_bridge_active_at_timestamp(&self, _t: u64) -> bool {
+            self.bridge_active
+        }
+    }
+
+    // The real `Evm` trait is large; the gate logic only needs the `transact_system_call`
+    // entry point. We define a narrow shim that mirrors the real signature for the gate paths
+    // and pass it through explicitly. This avoids pulling in a full EVM database harness for a
+    // pure decision-table test.
+    //
+    // For broader integration coverage (calldata round-trip, real state commit, EIP-7002
+    // ordering) see the integration test in the consuming reth crate.
+    fn run<F>(spec: &MockSpec, timestamp: u64, calldata: Option<&Bytes>, mut sink: F) -> bool
+    where
+        F: FnMut(Address, Address, Bytes),
+    {
+        // Mirror the gate logic from `transact_bridge_contract_call`. Returns `true` if the
+        // happy path would have been taken.
+        if !spec.is_bridge_active_at_timestamp(timestamp) {
+            return false;
+        }
+        let Some(target) = spec.bridge_contract_address() else { return false };
+        let cd = match calldata {
+            Some(b) if !b.is_empty() => b.clone(),
+            _ => return false,
+        };
+        sink(SYSTEM_ADDRESS, target, cd);
+        true
+    }
+
+    const BRIDGE_ADDR: Address = address!("0x00000000000000000000000000000000000000B0");
+
+    #[test]
+    fn no_op_when_fork_inactive() {
+        let spec =
+            MockSpec { bridge_address: Some(BRIDGE_ADDR), bridge_active: false };
+        let cd = Bytes::from_static(&[1, 2, 3, 4]);
+        let invoked =
+            run(&spec, 100, Some(&cd), |_, _, _| panic!("should not invoke when inactive"));
+        assert!(!invoked);
+    }
+
+    #[test]
+    fn no_op_when_address_missing() {
+        let spec = MockSpec { bridge_address: None, bridge_active: true };
+        let cd = Bytes::from_static(&[1, 2, 3, 4]);
+        let invoked = run(&spec, 100, Some(&cd), |_, _, _| panic!("should not invoke"));
+        assert!(!invoked);
+    }
+
+    #[test]
+    fn no_op_when_calldata_empty() {
+        let spec = MockSpec { bridge_address: Some(BRIDGE_ADDR), bridge_active: true };
+        let invoked = run(&spec, 100, None, |_, _, _| panic!("should not invoke for None"));
+        assert!(!invoked);
+        let empty = Bytes::new();
+        let invoked2 =
+            run(&spec, 100, Some(&empty), |_, _, _| panic!("should not invoke for empty"));
+        assert!(!invoked2);
+    }
+
+    #[test]
+    fn happy_path_uses_system_address_and_target() {
+        let spec = MockSpec { bridge_address: Some(BRIDGE_ADDR), bridge_active: true };
+        let cd = Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]);
+        let mut captured: Option<(Address, Address, Bytes)> = None;
+        let invoked = run(&spec, 100, Some(&cd), |caller, target, data| {
+            captured = Some((caller, target, data));
+        });
+        assert!(invoked);
+        let (caller, target, data) = captured.expect("happy path captured");
+        assert_eq!(caller, SYSTEM_ADDRESS);
+        assert_eq!(caller, EIP7002_SYSTEM_ADDRESS, "bridge reuses EIP-7002 SYSTEM_ADDRESS");
+        assert_eq!(target, BRIDGE_ADDR);
+        assert_eq!(data, Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]));
+    }
+}

--- a/crates/evm/src/block/system_calls/bridge.rs
+++ b/crates/evm/src/block/system_calls/bridge.rs
@@ -76,6 +76,15 @@ pub(crate) fn transact_bridge_contract_call<Halt>(
     let res = match evm.transact_system_call(SYSTEM_ADDRESS, target, cd) {
         Ok(res) => res,
         Err(e) => {
+            // Classified as an Internal (not Validation) BlockExecutionError, deliberately
+            // unlike the sibling system calls (eip7002/7251 use BlockValidationError::
+            // *ContractCall). parkRemoteMessages performs no token calls and cannot revert or
+            // halt — a deterministic revert/halt comes back as Ok(res) with a non-success
+            // result and is committed+logged by the caller. So reaching this Err arm means a
+            // non-deterministic infrastructure fault (e.g. an EVMError::Database), which is a
+            // node-local problem, not a defect in the block. Marking it Validation would let a
+            // transient local DB error invalidate a block the rest of the network accepts;
+            // Internal keeps the failure attributed to this node.
             return Err(BlockExecutionError::msg(format!(
                 "0G bridge system call execution failed: {e}"
             )));

--- a/crates/evm/src/block/system_calls/bridge.rs
+++ b/crates/evm/src/block/system_calls/bridge.rs
@@ -55,6 +55,13 @@ pub(crate) fn transact_bridge_contract_call<Halt>(
     };
 
     // Gate 3 + 4: non-empty calldata supplied by the engine API
+    //
+    // Note: an *empty message list* still produces non-empty calldata — ABI encoding of
+    // `executeRemoteMessages([])` is the 4-byte selector plus the empty-array head — so
+    // post-fork every block executes the system call exactly once, even with zero messages.
+    // Do NOT "optimize" this by skipping empty batches: whether the system call runs at all
+    // is consensus-sensitive, and any such change must land atomically in both the block
+    // build and block verify paths. A one-sided change immediately forks the state root.
     let cd = match calldata {
         Some(b) if !b.is_empty() => b.clone(),
         _ => return Ok(None),

--- a/crates/evm/src/block/system_calls/bridge.rs
+++ b/crates/evm/src/block/system_calls/bridge.rs
@@ -36,6 +36,10 @@ pub const BRIDGE_REQUEST_TYPE: u8 = 0xf0;
 /// no fee charged, no coinbase reward, executed against the same EVM state as block transactions.
 /// The state delta is **not** committed by this function — the caller is responsible for
 /// wiring the result into [`SystemCaller::on_state`] and calling `db.commit(...)`.
+///
+/// Gate behavior is covered end-to-end by the executor integration tests (`bridge_tests`) in
+/// the downstream reth repository, which exercise this function through a real EVM. This crate
+/// intentionally does not mirror the gate logic in unit tests, as such mirrors drift silently.
 #[inline]
 pub(crate) fn transact_bridge_contract_call<Halt>(
     spec: &impl EthExecutorSpec,
@@ -76,116 +80,4 @@ pub(crate) fn transact_bridge_contract_call<Halt>(
         }
     };
     Ok(Some(res))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy_eips::eip7002::SYSTEM_ADDRESS as EIP7002_SYSTEM_ADDRESS;
-    use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
-    use alloy_primitives::{address, Address};
-
-    /// Lightweight spec used to drive the gate logic. The wider `Evm` integration is exercised
-    /// by an integration test in the consuming reth crate against a real revm instance.
-    #[derive(Debug, Clone, Default)]
-    struct MockSpec {
-        bridge_address: Option<Address>,
-        bridge_active: bool,
-    }
-
-    impl EthereumHardforks for MockSpec {
-        fn ethereum_fork_activation(&self, _fork: EthereumHardfork) -> ForkCondition {
-            ForkCondition::Never
-        }
-    }
-
-    impl EthExecutorSpec for MockSpec {
-        fn deposit_contract_address(&self) -> Option<Address> {
-            None
-        }
-        fn staking_contract_address(&self) -> Option<Address> {
-            None
-        }
-        fn is_staking_activate_at_timestamp(&self, _t: u64) -> bool {
-            false
-        }
-        fn bridge_contract_address(&self) -> Option<Address> {
-            self.bridge_address
-        }
-        fn is_bridge_active_at_timestamp(&self, _t: u64) -> bool {
-            self.bridge_active
-        }
-    }
-
-    // The real `Evm` trait is large; the gate logic only needs the `transact_system_call`
-    // entry point. We define a narrow shim that mirrors the real signature for the gate paths
-    // and pass it through explicitly. This avoids pulling in a full EVM database harness for a
-    // pure decision-table test.
-    //
-    // For broader integration coverage (calldata round-trip, real state commit, EIP-7002
-    // ordering) see the integration test in the consuming reth crate.
-    fn run<F>(spec: &MockSpec, timestamp: u64, calldata: Option<&Bytes>, mut sink: F) -> bool
-    where
-        F: FnMut(Address, Address, Bytes),
-    {
-        // Mirror the gate logic from `transact_bridge_contract_call`. Returns `true` if the
-        // happy path would have been taken.
-        if !spec.is_bridge_active_at_timestamp(timestamp) {
-            return false;
-        }
-        let Some(target) = spec.bridge_contract_address() else { return false };
-        let cd = match calldata {
-            Some(b) if !b.is_empty() => b.clone(),
-            _ => return false,
-        };
-        sink(SYSTEM_ADDRESS, target, cd);
-        true
-    }
-
-    const BRIDGE_ADDR: Address = address!("0x00000000000000000000000000000000000000B0");
-
-    #[test]
-    fn no_op_when_fork_inactive() {
-        let spec =
-            MockSpec { bridge_address: Some(BRIDGE_ADDR), bridge_active: false };
-        let cd = Bytes::from_static(&[1, 2, 3, 4]);
-        let invoked =
-            run(&spec, 100, Some(&cd), |_, _, _| panic!("should not invoke when inactive"));
-        assert!(!invoked);
-    }
-
-    #[test]
-    fn no_op_when_address_missing() {
-        let spec = MockSpec { bridge_address: None, bridge_active: true };
-        let cd = Bytes::from_static(&[1, 2, 3, 4]);
-        let invoked = run(&spec, 100, Some(&cd), |_, _, _| panic!("should not invoke"));
-        assert!(!invoked);
-    }
-
-    #[test]
-    fn no_op_when_calldata_empty() {
-        let spec = MockSpec { bridge_address: Some(BRIDGE_ADDR), bridge_active: true };
-        let invoked = run(&spec, 100, None, |_, _, _| panic!("should not invoke for None"));
-        assert!(!invoked);
-        let empty = Bytes::new();
-        let invoked2 =
-            run(&spec, 100, Some(&empty), |_, _, _| panic!("should not invoke for empty"));
-        assert!(!invoked2);
-    }
-
-    #[test]
-    fn happy_path_uses_system_address_and_target() {
-        let spec = MockSpec { bridge_address: Some(BRIDGE_ADDR), bridge_active: true };
-        let cd = Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]);
-        let mut captured: Option<(Address, Address, Bytes)> = None;
-        let invoked = run(&spec, 100, Some(&cd), |caller, target, data| {
-            captured = Some((caller, target, data));
-        });
-        assert!(invoked);
-        let (caller, target, data) = captured.expect("happy path captured");
-        assert_eq!(caller, SYSTEM_ADDRESS);
-        assert_eq!(caller, EIP7002_SYSTEM_ADDRESS, "bridge reuses EIP-7002 SYSTEM_ADDRESS");
-        assert_eq!(target, BRIDGE_ADDR);
-        assert_eq!(data, Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]));
-    }
 }

--- a/crates/evm/src/block/system_calls/bridge.rs
+++ b/crates/evm/src/block/system_calls/bridge.rs
@@ -3,8 +3,10 @@
 //! This is the EL-side counterpart to the EIP-7685 request type `0xf0` carried on the engine
 //! API in 0G's private namespace. The CL beacon block emits a list of `BridgeMessage` items
 //! as SSZ bytes; the EL decodes them into ABI calldata for
-//! `Bridge.executeRemoteMessages(InboundMessage[])` and invokes the Bridge proxy contract
-//! from the canonical [`SYSTEM_ADDRESS`] just like EIP-4788/7002.
+//! `Bridge.parkRemoteMessages(InboundMessage[])` and invokes the Bridge proxy contract
+//! from the canonical [`SYSTEM_ADDRESS`] just like EIP-4788/7002. The call only *parks* each
+//! message into pending storage — it moves no tokens, charges no fee, and emits no events;
+//! actual delivery happens later in a permissionless `deliver` / `deliverBatch` user transaction.
 //!
 //! Activation is gated by [`EthExecutorSpec::is_bridge_active_at_timestamp`] and a configured
 //! [`EthExecutorSpec::bridge_contract_address`]. The hook is a no-op (returns `Ok(None)`) when
@@ -24,7 +26,7 @@ use revm::context_interface::result::ResultAndState;
 /// monotonic type-byte ordering required by the bridge schema.
 pub const BRIDGE_REQUEST_TYPE: u8 = 0xf0;
 
-/// Invokes `Bridge.executeRemoteMessages(InboundMessage[])` from [`SYSTEM_ADDRESS`].
+/// Invokes `Bridge.parkRemoteMessages(InboundMessage[])` from [`SYSTEM_ADDRESS`].
 ///
 /// Returns `Ok(None)` (no-op) if any of the following gates is closed:
 ///   * Bridge fork not active at `timestamp` (`spec.is_bridge_active_at_timestamp`)
@@ -61,8 +63,8 @@ pub(crate) fn transact_bridge_contract_call<Halt>(
     // Gate 3 + 4: non-empty calldata supplied by the engine API
     //
     // Note: an *empty message list* still produces non-empty calldata — ABI encoding of
-    // `executeRemoteMessages([])` is the 4-byte selector plus the empty-array head — so
-    // post-fork every block executes the system call exactly once, even with zero messages.
+    // `parkRemoteMessages([])` is the 4-byte selector plus the empty-array head — so
+    // post-fork every block runs the park system call exactly once, even with zero messages.
     // Do NOT "optimize" this by skipping empty batches: whether the system call runs at all
     // is consensus-sensitive, and any such change must land atomically in both the block
     // build and block verify paths. A one-sided change immediately forks the state root.

--- a/crates/evm/src/block/system_calls/mod.rs
+++ b/crates/evm/src/block/system_calls/mod.rs
@@ -15,7 +15,7 @@ use revm::{state::EvmState, DatabaseCommit};
 
 use super::{StateChangePostBlockSource, StateChangePreBlockSource, StateChangeSource};
 
-pub(crate) mod bridge;
+pub mod bridge;
 mod eip2935;
 mod eip4788;
 mod eip7002;

--- a/crates/evm/src/block/system_calls/mod.rs
+++ b/crates/evm/src/block/system_calls/mod.rs
@@ -15,6 +15,7 @@ use revm::{state::EvmState, DatabaseCommit};
 
 use super::{StateChangePostBlockSource, StateChangePreBlockSource, StateChangeSource};
 
+pub(crate) mod bridge;
 mod eip2935;
 mod eip4788;
 mod eip7002;

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -58,10 +58,11 @@ pub struct EthBlockExecutionCtx<'a> {
     /// `CalcRequestsHash` over the same wire bytes). The bytes pass through verbatim — no
     /// decode → re-encode — so proposer and verifier emit byte-equal `executionRequests` lists.
     ///
-    /// `None` on the block-replay path (`context_for_block`) — the historical block's 0xf0 raw
-    /// bytes have no on-chain source (not in body, not in receipts), so replay skips the
-    /// 0xf0 push. The 0G `validate_block_post_execution` tolerates this by overwriting
-    /// `requests_hash` on the in-memory header rather than diffing against the sealed value.
+    /// On the block-replay path (`context_for_block`) the raw blob is recovered from the block
+    /// body (`BlockBody.bridge_requests`, carried on-chain for exactly this purpose), so replay
+    /// re-pushes the 0xf0 entry verbatim and the re-executed block reproduces the sealed
+    /// `requests_hash`. It is only `None` for a body that carries no bridge blob (pre-Bridge
+    /// blocks).
     pub bridge_request_raw: Option<Cow<'a, Bytes>>,
 }
 
@@ -273,11 +274,9 @@ where
         //     divergence from the network. Bridge-active strictly implies Prague-active (chain
         //     spec invariant), so this is monotonically stricter than the old Prague gate.
         //   * `bridge_request_raw` was supplied (build path = `attrs.bridgeRequests`; verify
-        //     path = 0xf0 entry of `payload.executionRequests`). On replay (`context_for_block`)
-        //     the field is `None` and we skip — there is no on-chain source to recover the raw
-        //     SSZ from. The 0G `validate_block_post_execution` tolerates this by overwriting
-        //     `requests_hash` on the in-memory header rather than diffing against the sealed
-        //     value.
+        //     path = 0xf0 entry of `payload.executionRequests`; replay path = `context_for_block`
+        //     recovers it from `BlockBody.bridge_requests`). Only a body with no bridge blob
+        //     (pre-Bridge block) yields `None`, in which case no 0xf0 entry is pushed.
         if bridge_active {
             if let Some(raw) = self.ctx.bridge_request_raw.as_deref() {
                 requests.push_request_with_type(bridge::BRIDGE_REQUEST_TYPE, raw.clone());

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -228,6 +228,18 @@ where
             self.ctx.bridge_request.as_deref(),
             &mut self.evm,
         )? {
+            // parkRemoteMessages is revert/halt-free by contract design (SYSTEM_ADDRESS gate plus a
+            // write-only loop), so a non-success here means that invariant was broken — e.g. a bad
+            // contract upgrade, or an EL/CL calldata-encoding regression. The messages were then NOT
+            // parked while the CL nonce watermark still advances, silently dropping them. Surface it
+            // loudly. The result is deterministic on both the build and verify paths, so logging
+            // here cannot itself cause consensus divergence.
+            if !res.result.is_success() {
+                tracing::error!(
+                    result = ?res.result,
+                    "bridge parkRemoteMessages system call did not succeed; inbound messages were not parked"
+                );
+            }
             self.system_caller.on_state(
                 StateChangeSource::PostBlock(StateChangePostBlockSource::BridgeExecution),
                 &res.state,

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -36,7 +36,7 @@ pub struct EthBlockExecutionCtx<'a> {
     pub withdrawals: Option<Cow<'a, Withdrawals>>,
     /// Block timestamp.
     pub timestamp: u64,
-    /// 0G: Pre-encoded ABI calldata for `Bridge.executeRemoteMessages(InboundMessage[])`.
+    /// 0G: Pre-encoded ABI calldata for `Bridge.parkRemoteMessages(InboundMessage[])`.
     ///
     /// Populated by the EL engine API when it observes an EIP-7685 request with type byte
     /// `0xf0` on a payload built after the Bridge fork (private 0G namespace). `None` when

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -52,12 +52,13 @@ pub struct EthBlockExecutionCtx<'a> {
     /// [`super::EthBlockExecutor::finish`]. Including it in the `requests` slice **before** the
     /// block assembler computes `requests_hash` is what guarantees the proposer-built sealed
     /// `block.header.requests_hash` matches the verifier's reconstruction (CL re-runs
-    /// `CalcRequestsHash` over the same wire bytes). See plan §1.6.4 / §2.A.10.
+    /// `CalcRequestsHash` over the same wire bytes). The bytes pass through verbatim — no
+    /// decode → re-encode — so proposer and verifier emit byte-equal `executionRequests` lists.
     ///
     /// `None` on the block-replay path (`context_for_block`) — the historical block's 0xf0 raw
-    /// bytes have no on-chain source (not in body, not in receipts), and the 0G `validate_block_post_execution`
-    /// is lenient (overwrites header rather than diffs), so omitting the entry is byte-for-byte
-    /// equivalent to the pre-fix replay behaviour.
+    /// bytes have no on-chain source (not in body, not in receipts), so replay skips the
+    /// 0xf0 push. The 0G `validate_block_post_execution` tolerates this by overwriting
+    /// `requests_hash` on the in-memory header rather than diffing against the sealed value.
     pub bridge_request_raw: Option<Cow<'a, Bytes>>,
 }
 
@@ -229,21 +230,20 @@ where
             self.evm.db_mut().commit(res.state);
         }
 
-        // 0G: Append the EIP-7685 type-0xf0 bridge entry to the executionRequests list using the
-        // **original SSZ blob** the CL forwarded (not recomputed). Must happen here — before
-        // `EthBlockAssembler::assemble_block` reads `requests` to compute `requests_hash` — so
-        // the proposer-built sealed `block.header.requests_hash` covers the 0xf0 entry. Without
-        // this, the EL header omits 0xf0 while the wire response includes it, and the CL's
-        // re-assembled block hash diverges from `payload.block_hash`.
+        // 0G: Append the EIP-7685 type-0xf0 bridge entry to the executionRequests list using
+        // the **original SSZ blob** the CL forwarded (not recomputed). Must happen here —
+        // before `EthBlockAssembler::assemble_block` reads `requests` to compute
+        // `requests_hash` — so the proposer-built sealed `block.header.requests_hash` covers
+        // the 0xf0 entry and matches what the CL reconstructs from the same wire bytes.
         //
         // Only push when:
         //   * Prague is active (matches the `requests_hash` gate in `EthBlockAssembler`).
         //   * `bridge_request_raw` was supplied (build path = `attrs.bridgeRequests`; verify
         //     path = 0xf0 entry of `payload.executionRequests`). On replay (`context_for_block`)
         //     the field is `None` and we skip — there is no on-chain source to recover the raw
-        //     SSZ from, and the 0G `validate_block_post_execution` is lenient (overwrites
-        //     header without diff), so the omission is byte-equivalent to the pre-fix replay
-        //     path.
+        //     SSZ from. The 0G `validate_block_post_execution` tolerates this by overwriting
+        //     `requests_hash` on the in-memory header rather than diffing against the sealed
+        //     value.
         if prague_active {
             if let Some(raw) = self.ctx.bridge_request_raw.as_deref() {
                 requests.push_request_with_type(bridge::BRIDGE_REQUEST_TYPE, raw.clone());

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -193,9 +193,14 @@ where
     fn finish(
         mut self,
     ) -> Result<(Self::Evm, BlockExecutionResult<R::Receipt>), BlockExecutionError> {
-        let prague_active = self
-            .spec
-            .is_prague_active_at_timestamp(self.evm.block().timestamp.saturating_to());
+        // Single source of truth for the block timestamp used by every fork-activation gate in
+        // this function (Prague for the standard EIP-7685 entries, Bridge for the 0xf0 entry +
+        // system call). `ctx.timestamp` is the value the caller wrote into both `EthBlockExecutionCtx`
+        // and `evm.block().timestamp` when constructing the executor, so the two sources are
+        // equal by construction — bind once to avoid silent drift if either is later refactored.
+        let timestamp = self.ctx.timestamp;
+        let prague_active = self.spec.is_prague_active_at_timestamp(timestamp);
+        let bridge_active = self.spec.is_bridge_active_at_timestamp(timestamp);
 
         let mut requests = if prague_active {
             // Collect all EIP-6110 deposits
@@ -219,7 +224,7 @@ where
         // post-block balance increments. Gated by `EthExecutorSpec::is_bridge_active_at_timestamp`.
         if let Some(res) = bridge::transact_bridge_contract_call(
             &self.spec,
-            self.ctx.timestamp,
+            timestamp,
             self.ctx.bridge_request.as_deref(),
             &mut self.evm,
         )? {
@@ -237,14 +242,19 @@ where
         // the 0xf0 entry and matches what the CL reconstructs from the same wire bytes.
         //
         // Only push when:
-        //   * Prague is active (matches the `requests_hash` gate in `EthBlockAssembler`).
+        //   * Bridge fork is active at `timestamp` — same gate as `transact_bridge_contract_call`
+        //     above. Gating on Prague alone would allow a pre-Bridge / post-Prague block (or a
+        //     byzantine `engine_newPayloadV4` carrying a 0xf0 entry) to seal a `requests_hash`
+        //     that covers a 0xf0 entry the bridge system call did NOT execute — silent state
+        //     divergence from the network. Bridge-active strictly implies Prague-active (chain
+        //     spec invariant), so this is monotonically stricter than the old Prague gate.
         //   * `bridge_request_raw` was supplied (build path = `attrs.bridgeRequests`; verify
         //     path = 0xf0 entry of `payload.executionRequests`). On replay (`context_for_block`)
         //     the field is `None` and we skip — there is no on-chain source to recover the raw
         //     SSZ from. The 0G `validate_block_post_execution` tolerates this by overwriting
         //     `requests_hash` on the in-memory header rather than diffing against the sealed
         //     value.
-        if prague_active {
+        if bridge_active {
             if let Some(raw) = self.ctx.bridge_request_raw.as_deref() {
                 requests.push_request_with_type(bridge::BRIDGE_REQUEST_TYPE, raw.clone());
             }
@@ -287,7 +297,7 @@ where
                 // ProcessStakingDistribution
                 let data = withdrawals[0].amount_wei().to_be_bytes::<32>();
                 let mut contract = withdrawals[0].address;
-                if self.spec.is_staking_activate_at_timestamp(self.ctx.timestamp) {
+                if self.spec.is_staking_activate_at_timestamp(timestamp) {
                     contract = self.spec.staking_contract_address().unwrap_or(address!("0xea224dBB52F57752044c0C86aD50930091F561B9"));
                 }
 

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -9,6 +9,7 @@ use super::{
 use crate::{
     block::{
         state_changes::{balance_increment_state, post_block_balance_increments},
+        system_calls::bridge,
         BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockExecutorFactory,
         BlockExecutorFor, BlockValidationError, ExecutableTx, OnStateHook,
         StateChangePostBlockSource, StateChangeSource, SystemCaller,
@@ -35,6 +36,29 @@ pub struct EthBlockExecutionCtx<'a> {
     pub withdrawals: Option<Cow<'a, Withdrawals>>,
     /// Block timestamp.
     pub timestamp: u64,
+    /// 0G: Pre-encoded ABI calldata for `Bridge.executeRemoteMessages(InboundMessage[])`.
+    ///
+    /// Populated by the EL engine API when it observes an EIP-7685 request with type byte
+    /// `0xf0` on a payload built after the Bridge fork (private 0G namespace). `None` when
+    /// either the fork is inactive, no bridge messages were emitted by CL, or the chain spec
+    /// does not configure a bridge contract address.
+    pub bridge_request: Option<Cow<'a, Bytes>>,
+    /// 0G: Original SSZ-encoded `BridgeRequests` blob the CL forwarded on
+    /// `engine_forkchoiceUpdatedV4.payloadAttributes.bridgeRequests` (build path) or extracted
+    /// from `payload.executionRequests` 0xf0 entry (verify path).
+    ///
+    /// Distinct from `bridge_request` (ABI calldata for the system call). This raw SSZ blob is
+    /// what gets re-emitted as the `0xf0` EIP-7685 entry in the requests list returned by
+    /// [`super::EthBlockExecutor::finish`]. Including it in the `requests` slice **before** the
+    /// block assembler computes `requests_hash` is what guarantees the proposer-built sealed
+    /// `block.header.requests_hash` matches the verifier's reconstruction (CL re-runs
+    /// `CalcRequestsHash` over the same wire bytes). See plan §1.6.4 / §2.A.10.
+    ///
+    /// `None` on the block-replay path (`context_for_block`) — the historical block's 0xf0 raw
+    /// bytes have no on-chain source (not in body, not in receipts), and the 0G `validate_block_post_execution`
+    /// is lenient (overwrites header rather than diffs), so omitting the entry is byte-for-byte
+    /// equivalent to the pre-fix replay behaviour.
+    pub bridge_request_raw: Option<Cow<'a, Bytes>>,
 }
 
 /// Block executor for Ethereum.
@@ -168,10 +192,11 @@ where
     fn finish(
         mut self,
     ) -> Result<(Self::Evm, BlockExecutionResult<R::Receipt>), BlockExecutionError> {
-        let requests = if self
+        let prague_active = self
             .spec
-            .is_prague_active_at_timestamp(self.evm.block().timestamp.saturating_to())
-        {
+            .is_prague_active_at_timestamp(self.evm.block().timestamp.saturating_to());
+
+        let mut requests = if prague_active {
             // Collect all EIP-6110 deposits
             let deposit_requests =
                 eip6110::parse_deposits_from_receipts(&self.spec, &self.receipts)?;
@@ -187,6 +212,43 @@ where
         } else {
             Requests::default()
         };
+
+        // 0G: Bridge inbound system call. Runs after EIP-7002/7251 post-execution requests
+        // (so witness coverage is co-located with the existing requests pipeline) and before
+        // post-block balance increments. Gated by `EthExecutorSpec::is_bridge_active_at_timestamp`.
+        if let Some(res) = bridge::transact_bridge_contract_call(
+            &self.spec,
+            self.ctx.timestamp,
+            self.ctx.bridge_request.as_deref(),
+            &mut self.evm,
+        )? {
+            self.system_caller.on_state(
+                StateChangeSource::PostBlock(StateChangePostBlockSource::BridgeExecution),
+                &res.state,
+            );
+            self.evm.db_mut().commit(res.state);
+        }
+
+        // 0G: Append the EIP-7685 type-0xf0 bridge entry to the executionRequests list using the
+        // **original SSZ blob** the CL forwarded (not recomputed). Must happen here — before
+        // `EthBlockAssembler::assemble_block` reads `requests` to compute `requests_hash` — so
+        // the proposer-built sealed `block.header.requests_hash` covers the 0xf0 entry. Without
+        // this, the EL header omits 0xf0 while the wire response includes it, and the CL's
+        // re-assembled block hash diverges from `payload.block_hash`.
+        //
+        // Only push when:
+        //   * Prague is active (matches the `requests_hash` gate in `EthBlockAssembler`).
+        //   * `bridge_request_raw` was supplied (build path = `attrs.bridgeRequests`; verify
+        //     path = 0xf0 entry of `payload.executionRequests`). On replay (`context_for_block`)
+        //     the field is `None` and we skip — there is no on-chain source to recover the raw
+        //     SSZ from, and the 0G `validate_block_post_execution` is lenient (overwrites
+        //     header without diff), so the omission is byte-equivalent to the pre-fix replay
+        //     path.
+        if prague_active {
+            if let Some(raw) = self.ctx.bridge_request_raw.as_deref() {
+                requests.push_request_with_type(bridge::BRIDGE_REQUEST_TYPE, raw.clone());
+            }
+        }
 
         let mut balance_increments = post_block_balance_increments(
             &self.spec,

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -199,6 +199,15 @@ where
         // and `evm.block().timestamp` when constructing the executor, so the two sources are
         // equal by construction — bind once to avoid silent drift if either is later refactored.
         let timestamp = self.ctx.timestamp;
+        // The "equal by construction" invariant above is only enforced by convention at the call
+        // site; assert it in debug builds so an accidental divergence between the two timestamp
+        // sources fails loudly in tests rather than silently mis-gating a fork activation. No
+        // effect on release behavior.
+        debug_assert_eq!(
+            timestamp,
+            self.evm.block().timestamp.saturating_to::<u64>(),
+            "ctx.timestamp must equal evm.block().timestamp",
+        );
         let prague_active = self.spec.is_prague_active_at_timestamp(timestamp);
         let bridge_active = self.spec.is_bridge_active_at_timestamp(timestamp);
 

--- a/crates/evm/src/eth/block.rs
+++ b/crates/evm/src/eth/block.rs
@@ -20,7 +20,7 @@ use alloc::{borrow::Cow, boxed::Box, vec::Vec};
 use alloy_consensus::{Header, Transaction, TxReceipt};
 use alloy_eips::{eip4895::Withdrawals, eip7685::Requests, Encodable2718};
 use alloy_hardforks::EthereumHardfork;
-use alloy_primitives::{address, bytes, Address, Bytes, Log, B256};
+use alloy_primitives::{address, Bytes, Log, B256};
 use revm::{context_interface::result::ResultAndState, database::State, DatabaseCommit, Inspector};
 
 /// Context for Ethereum block execution.

--- a/crates/evm/src/eth/spec.rs
+++ b/crates/evm/src/eth/spec.rs
@@ -17,6 +17,22 @@ pub trait EthExecutorSpec: EthereumHardforks {
 
     /// Convenience method to check if staking contract is active at a given timestamp.
     fn is_staking_activate_at_timestamp(&self, timestamp: u64) -> bool;
+
+    /// Address of the Bridge contract used for cross-chain inbound message execution.
+    ///
+    /// Returning `None` disables the bridge system call regardless of
+    /// [`Self::is_bridge_active_at_timestamp`].
+    fn bridge_contract_address(&self) -> Option<Address> {
+        None
+    }
+
+    /// Convenience method to check if the Bridge fork is active at a given timestamp.
+    ///
+    /// Default implementation returns `false` so chains that have not opted into the bridge
+    /// continue to behave exactly as before.
+    fn is_bridge_active_at_timestamp(&self, _timestamp: u64) -> bool {
+        false
+    }
 }
 
 /// Basic Ethereum specification.

--- a/crates/evm/src/eth/spec.rs
+++ b/crates/evm/src/eth/spec.rs
@@ -83,7 +83,7 @@ impl EthExecutorSpec for EthSpec {
         None
     }
 
-    fn is_staking_activate_at_timestamp(&self, timestamp: u64) -> bool {
+    fn is_staking_activate_at_timestamp(&self, _timestamp: u64) -> bool {
         false
     }
 }


### PR DESCRIPTION
## Summary

Adds a 0G cross-chain bridge hook to the Ethereum block executor. In `EthBlockExecutor::finish()`, after the standard EIP-7002/7251 post-execution system calls, the executor invokes `Bridge.parkRemoteMessages(InboundMessage[])` from `SYSTEM_ADDRESS` with pre-encoded calldata supplied on the block execution context, then appends the original SSZ bridge blob as an EIP-7685 type-`0xf0` entry (private 0G namespace) before the assembler computes `requests_hash`.

The system call only **parks** inbound messages into the Bridge contract's pending storage — it moves no tokens, charges no fee, and emits no events. Actual delivery happens later in permissionless `deliver`/`deliverBatch` user transactions (park-then-deliver). This crate treats both byte blobs as opaque: the SSZ decode and ABI encode live in the downstream reth crate; `alloy-evm` dispatches the calldata unchanged.

What's in this PR:

- **New `crates/evm/src/block/system_calls/bridge.rs`.** `transact_bridge_contract_call` uses standard `transact_system_call` semantics (30M gas, no fee, no coinbase reward) and returns the uncommitted `ResultAndState`; the caller commits it via the same `SystemCaller::on_state` + `db.commit` pattern as the sibling EIP-7002/7251 calls (with a new `StateChangePostBlockSource::BridgeExecution` source).
- **`pub const BRIDGE_REQUEST_TYPE: u8 = 0xf0`**, matching the `eip6110::DEPOSIT_REQUEST_TYPE` convention. Emitted as the **last** requests entry, strictly after the standard `0x00`/`0x01`/`0x02` types, satisfying EIP-7685's monotonic type-byte ordering.
- **`EthBlockExecutionCtx` carries two bridge fields.** `bridge_request` is the ABI calldata consumed by the system call; `bridge_request_raw` is the original SSZ blob the CL forwarded, re-emitted verbatim as the `0xf0` entry (no decode → re-encode), so the proposer-built `requests_hash` matches the CL's reconstruction over the same wire bytes.

## Behavior

Ordering in `finish()`: EIP-6110 deposit parsing → EIP-7002/7251 system calls → bridge park system call → `0xf0` entry append → post-block balance increments; `requests_hash` is computed afterwards by the block assembler, so the sealed header covers the bridge entry by construction.

Gating — the hook is a no-op (`Ok(None)`) unless all of the following hold, so non-0G chains are byte-for-byte unchanged:

1. Bridge fork active at the block timestamp (`EthExecutorSpec::is_bridge_active_at_timestamp`, default `false`);
2. a bridge contract address is configured (`EthExecutorSpec::bridge_contract_address`, default `None`);
3. non-empty calldata was attached to the block context.

The `0xf0` append is gated on the same fork check (not Prague alone) plus a supplied `bridge_request_raw`, so a `requests_hash` can never cover a `0xf0` entry the system call did not execute. Note that an *empty message list* still ABI-encodes to non-empty calldata (selector + empty-array head), so post-fork every block runs the park call exactly once; whether the call runs at all is consensus-sensitive and gate changes must land atomically on the build and verify paths.

Error semantics — deliberately unlike the sibling system calls:

- An `Err` from the EVM (e.g. a database fault) maps to `BlockExecutionError::Internal`, **not** `Validation`. `parkRemoteMessages` performs no token calls and cannot deterministically revert or halt, so reaching the `Err` arm means a node-local infrastructure fault; classifying it as `Validation` would let a transient local error invalidate a block the rest of the network accepts.
- A deterministic non-success result (`Ok` with revert/halt — only possible if the contract's revert-free invariant is broken, e.g. a bad upgrade or a calldata-encoding regression) is committed and logged at error level, but does not fail block processing. The outcome is identical on the build and verify paths, so logging cannot cause divergence.

## API changes (breaking for downstream)

- `EthBlockExecutionCtx` gains two `pub` fields: `bridge_request: Option<Cow<'a, Bytes>>` and `bridge_request_raw: Option<Cow<'a, Bytes>>` — breaking for any code constructing the ctx as a struct literal.
- `StateChangePostBlockSource` gains a `BridgeExecution` variant — breaking for exhaustive matches.
- `EthExecutorSpec` gains two **defaulted** methods (`bridge_contract_address` → `None`, `is_bridge_active_at_timestamp` → `false`) — non-breaking; existing impls compile unchanged and keep the hook disabled.
- New `pub const BRIDGE_REQUEST_TYPE` in `system_calls::bridge`.
- New workspace dependency: `tracing` (for the non-success error log).

The sole consumer of this fork is the companion `0g-reth` PR, which patches this crate via `[patch]` in `Cargo.toml` and updates its ctx constructions in the same change. That PR decodes the SSZ blob the CL forwards, encodes the `parkRemoteMessages` calldata, and populates both ctx fields on the build, verify, and replay paths.

## Verification

- [x] `cargo check -p alloy-evm` clean
- [x] `cargo test -p alloy-evm` — existing suite (39 unit tests + 9 doc-tests) passes unchanged
- This PR adds **no in-repo tests** for the new code. Gate behavior and the end-to-end path are covered downstream: the companion `0g-reth` PR's executor integration tests (`bridge_tests`) exercise `transact_bridge_contract_call` through a real EVM on the build/verify/replay paths, and multi-chain devnet integration scenarios (token round-trips, multi-message batches, replay defence, multi-satellite fan-in) exercise the full CL → EL pipeline. This crate intentionally does not mirror the gate logic in unit tests, as such mirrors drift silently.

## Companion PRs

- `0g-reth` — engine-API plumbing, SSZ decode / ABI encode, ctx population; depends on this PR.
- Consensus layer (primary + satellite chain branches) — emits the bridge blob and reconstructs `requests_hash` over the same bytes.
- Solidity `Bridge` contracts — `parkRemoteMessages` (system-call-gated park) plus permissionless `deliver`/`deliverBatch`.

